### PR TITLE
MEDIAセクションの表示崩れ修正 #22

### DIFF
--- a/src/scss/layouts/_media.scss
+++ b/src/scss/layouts/_media.scss
@@ -11,7 +11,7 @@
 }
 
 .media__fig iframe {
-  width: 320px;
+  width: 100%;
   height: 180px;
   vertical-align: bottom;
 }
@@ -41,12 +41,14 @@
     display: flex;
     align-items: center;
     padding: 0;
-    height: 278px;
     border: 1px solid #DDDDDD;
   }
-  .media__fig iframe {
-    width: 494px;
+  .media__fig {
     height: 278px;
+    iframe {
+      width: 494px;
+      height: 278px;
+    }
   }
   .media__text {
     margin: 88px 32px;
@@ -58,6 +60,7 @@
     }
     p {
       font-size: 13px;
+      font-weight: lighter;
       line-height: 19px;
       padding: 0;
       margin-top: 16px;

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -12,11 +12,12 @@
 @import "layouts/popular";
 @import "layouts/footer";
 @import "layouts/feature";
+@import "layouts/media";
+
 
 @import "components/hero";
 @import "components/heading";
 @import "components/table";
 @import "components/button";
 @import "components/section";
-@import "components/media";
 @import "components/card";


### PR DESCRIPTION
## Issue

#22 

## スクリーンショット

![screenshot-2018-4-27 title 2](https://user-images.githubusercontent.com/24585873/39351123-7579392c-4a3b-11e8-8b7f-0aed00e10eba.png)
![screenshot-2018-4-27 title 3](https://user-images.githubusercontent.com/24585873/39351125-7a1e3e5a-4a3b-11e8-8822-85db6f139284.png)

## 概要

ブレークポイント付近のテキストの表示崩れとメディア周辺の余白を修正しました。またファイルの移動など軽微な修正を行いました。

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
