### PR TITLE
カルセール内、余白の修正#48

### DIFF
--- a/src/scss/layouts/_carousel.scss
+++ b/src/scss/layouts/_carousel.scss
@@ -1,5 +1,4 @@
 .carousel {
-  display: flex;
   color: #FFF;
   overflow: hidden;
   text-align: center;


### PR DESCRIPTION
## Issue
#48 
## スクリーンショット

<img width="728" alt="2018-04-28 20 09 44" src="https://user-images.githubusercontent.com/11908603/39395928-2538550c-4b20-11e8-8825-25109e1a3e0b.png">

<img width="388" alt="2018-04-28 20 09 33" src="https://user-images.githubusercontent.com/11908603/39395930-28fb9406-4b20-11e8-9522-74767dbc1c57.png">

## 概要
カルセール下部のドットとカートに追加ボタンの間の余白の修正しました。

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
