### PR TITLE
POPULAR　カードの修正#49

### DIFF
--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -74,7 +74,7 @@
     font-size: 12px;
     line-height: 21px;
     padding: 3px 4px;
-    margin: 0 8px 0 0;
+    margin: 0 7px 0 0;
   }
   &__footer {
     display: flex;


### PR DESCRIPTION
## Issue

#49 

## スクリーンショット

<img width="397" alt="2018-04-28 20 15 57" src="https://user-images.githubusercontent.com/11908603/39395984-0027592e-4b21-11e8-9729-1c6fcbb33c58.png">

## 概要

カードタグの表示崩れを修正

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
