### PR TITLE
MEDIAセクションのタイトル表示崩れ修正 #67

### DIFF
--- a/src/pug/layouts/_media.pug
+++ b/src/pug/layouts/_media.pug
@@ -1,8 +1,8 @@
 section#media.section.section--gray
   +heading('MEDIA', 'メディア')
   +media('<iframe src="https://www.youtube.com/embed/QwievZ1Tx-8" allow="autoplay; encrypted-media" style="border:0" allowfullscreen></iframe>')
-    h2 インフィニティ・プラモデルウォー
-    p STAGE-2 カンパニー製のプラモデルが集結し、大迫力のアクションを繰り広げます。どのプラモデルも初心者にとって非常に作りやすくなっており、平均２〜３分で組み立てが完了します。
+    h2.media__title インフィニティ・プラモデルウォー
+    p.media__text STAGE-2 カンパニー製のプラモデルが集結し、大迫力のアクションを繰り広げます。どのプラモデルも初心者にとって非常に作りやすくなっており、平均２〜３分で組み立てが完了します。
   +media('<iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2689.2891732781713!2d-122.3514660849036!3d47.6205098950111!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x5490151f4ed5b7f9%3A0xdb2ba8689ed0920d!2z44K544Oa44O844K544OL44O844OJ44Or!5e0!3m2!1sja!2sjp!4v1524278717558" style="border:0" allowfullscreen></iframe>')
-    h2 イベント開催のお知らせ
-    p 東京ドームにプラモデル初心者が集まり、みんなで東京ドームの3つ分のプラモデルドームを作成します！はじめてプラモデルに触る方が対象なので、プラモデル経験者はご遠慮ください。
+    h2.media__title イベント開催のお知らせ
+    p.media__text 東京ドームにプラモデル初心者が集まり、みんなで東京ドームの3つ分のプラモデルドームを作成します！はじめてプラモデルに触る方が対象なので、プラモデル経験者はご遠慮ください。

--- a/src/pug/lib/_media-content.pug
+++ b/src/pug/lib/_media-content.pug
@@ -2,5 +2,5 @@ mixin media(src)
   .container.media
     figure.media__fig
       != src
-    .media__text
+    .media__caption
       block

--- a/src/scss/layouts/_media.scss
+++ b/src/scss/layouts/_media.scss
@@ -10,20 +10,21 @@
   background: #FFF;
 }
 
-.media__fig iframe {
-  width: 100%;
-  height: 180px;
-  vertical-align: bottom;
-}
-
-.media__text {
-  h3 {
+.media {
+  &__fig {
+    iframe {
+      width: 100%;
+      height: 180px;
+      vertical-align: bottom;
+    }
+  }
+  &__title {
     font-size: 16px;
     line-height: 24px;
     padding-top: 16px;
     text-align: center;
   }
-  p {
+  &__text {
     font-size: 12px;
     font-weight: 300;
     line-height: 18px;
@@ -44,22 +45,24 @@
     padding: 0;
     border: 1px solid #DDDDDD;
   }
-  .media__fig {
-    height: 278px;
-    iframe {
-      width: 494px;
+  .media {
+    &__fig {
       height: 278px;
+      iframe {
+        width: 494px;
+        height: 278px;
+      }
     }
-  }
-  .media__text {
-    margin: 88px 32px;
-    h3 {
+    &__caption {
+      margin: 88px 32px;
+    }
+    &__title {
       font-size: 20px;
       line-height: 29px;
       padding: 0;
       text-align: left;
     }
-    p {
+    &__text {
       font-size: 13px;
       line-height: 19px;
       padding: 0;


### PR DESCRIPTION
## Issue

#67 

## 概要

SP版でMEDIAセクションのタイトルの表示が崩れてしまっていたのを修正しました。

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
