### PR TITLE
faviconのパスを指定 #40

### DIFF
--- a/src/pug/layouts/_base.pug
+++ b/src/pug/layouts/_base.pug
@@ -15,6 +15,7 @@ html(lang='ja')
     link(rel='stylesheet' href='https://fonts.googleapis.com/icon?family=Material+Icons')
     link(rel='stylesheet' href='https://use.fontawesome.com/releases/v5.0.6/css/all.css')
     link(rel='stylesheet' href='./style.css')
+    link(rel='icon' href='./favicon.ico')
     block meta
   body
     include /lib/_footer-content


### PR DESCRIPTION
## Issue

#40 

## 概要

- github pagesでfaviconのデフォルト位置がルートパスになっているため表示されていなかったようなので、head内でパス指定しました。
- https://update-hub.github.io/stage-2-antyoku/ でfaviconが表示されていることを確認してください。

## PRを出す前に以下のチェックを行いました。

- [ ] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
