### PR TITLE
グラデーションの修正 #71

### DIFF
--- a/src/scss/layouts/_carousel.scss
+++ b/src/scss/layouts/_carousel.scss
@@ -7,7 +7,7 @@
     margin-top: 170px;
     height: 332px;
     padding-top: 64px;
-    background-image: linear-gradient(180deg,rgba(255, 255, 255, 0) 0,rgb(0, 0, 0) 100%);
+    background-image: linear-gradient(rgba(255, 255, 255, 0) ,rgb(0, 0, 0));
     @include pc () {
       margin-top: 470px;
       padding-top: 0;


### PR DESCRIPTION
## Issue

#71 

スクリーンショット

<img width="361" alt="2018-05-02 11 53 49" src="https://user-images.githubusercontent.com/11908603/39503208-8eda6a72-4dff-11e8-9256-5bd4fb6ce89f.png">

## 概要
` linear-gradient(180deg,rgba(255, 255, 255, 0) 0,rgb(0, 0, 0) 100%) `　を
` linear-gradient(rgba(255, 255, 255, 0) ,rgb(0, 0, 0) ) ` に変更しました。

- pcブラウザーでは以前から正しく表示されていましたが、今回スマホ実機での確認が出来ていません。


## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
