### PR TITLE
heroロゴの縦中央揃え #79

### DIFF
--- a/src/scss/components/_hero.scss
+++ b/src/scss/components/_hero.scss
@@ -13,11 +13,13 @@
     font-size: 30px;
     font-family: 'Righteous', cursive;
     height: 38px;
+    line-height: 38px;
     padding: 17px 28px;
     border: 4px solid #FFFFFF;
     @include pc () {
       font-size: 50px;
       height: 62px;
+      line-height: 62px;
       padding: 21px 32px 29px;
       border: 8px solid #FFFFFF;
     }


### PR DESCRIPTION
## Issue

#79 

## スクリーンショット

![screenshot-2018-5-3 stage-2 1](https://user-images.githubusercontent.com/24585873/39574182-2eee5fca-4f11-11e8-8fd5-e9f424643d52.png)

## 概要

heroのロゴにline-heightを設定し、文字を縦中央揃えにしました。

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [x] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
