### PR TITLE
popular.scssの削除 #86

### DIFF
--- a/src/scss/layouts/_container.scss
+++ b/src/scss/layouts/_container.scss
@@ -8,4 +8,10 @@
   &--header {
     height: 100%;
   }
+  &__card-area {
+    margin-top: 40px;
+    @include pc() {
+      margin-top: 32px;
+    }
+  }
 }

--- a/src/scss/layouts/_popular.scss
+++ b/src/scss/layouts/_popular.scss
@@ -1,6 +1,0 @@
-.container__card-area {
-  margin-top: 40px;
-  @include pc() {
-    margin-top: 32px;
-  }
-}

--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -2,24 +2,19 @@
 @import url('https://fonts.googleapis.com/css?family=Righteous');
 @import url(//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick.css);
 @import url(//cdn.jsdelivr.net/gh/kenwheeler/slick@1.8.1/slick/slick-theme.css);
-@import "lib/variables";
 @import "lib/mixins";
 @import "lib/reset";
-@import "lib/init";
 @import "lib/common";
 
 @import "layouts/grid";
 @import "layouts/container";
 @import "layouts/header";
-@import "layouts/popular";
 @import "layouts/footer";
 @import "layouts/media";
 @import "layouts/carousel";
 
-
 @import "components/hero";
 @import "components/heading";
-@import "components/table";
 @import "components/button";
 @import "components/section";
 @import "components/card";


### PR DESCRIPTION
## Issue

#86 

## 概要

- containerのelementをcontainer.scssに移動し、popular.scssは空になったので削除しました。

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [ ] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
