### PR TITLE
カード設計の見直し #78

### DIFF
--- a/src/pug/lib/_popular-card.pug
+++ b/src/pug/lib/_popular-card.pug
@@ -2,15 +2,15 @@ mixin popular-card(cardImg, cardName, cardCap, cardTags, cardPrice)
   .col.col--4
     .card
       .card__img(class=cardImg)
-      .card__heart
+      a.card__heart
       .card__text-area
         h2.card__name #{cardName}
-        .card__caption #{cardCap}
+        p.card__caption #{cardCap}
         .card__tags-area
           each i in cardTags
             span.card__tags #{i}
         .card__footer
-          .card__price #{cardPrice}
-          .button.button-addcart
+          p.card__price #{cardPrice}
+          a.button.button-addcart
             i.material-icons-cart shopping_cart
             |  カートに追加

--- a/src/scss/components/_card.scss
+++ b/src/scss/components/_card.scss
@@ -8,6 +8,7 @@
   margin: 16px;
   @include pc() {
     width: auto;
+    min-width: 250px;
     margin: 0 -8px;
   }
   &__img {
@@ -74,7 +75,7 @@
     font-size: 12px;
     line-height: 21px;
     padding: 3px 4px;
-    margin: 0 7px 0 0;
+    margin: 0 7px 3px 0;
   }
   &__footer {
     display: flex;


### PR DESCRIPTION
## Issue

#78 

## スクリーンショット

![card0509](https://user-images.githubusercontent.com/36844789/39809510-f33ca88c-53bc-11e8-9f98-7c077d1a4e51.png)

## 概要

popular-card.pugおよびcard.scssを修正しました。
- クリックできる部分はaタグ、テキストはpタグに
- tagの折り返し時に上下余白ができるよう調整
- pc表示のときカードの幅が小さすぎると見栄えが悪いので最低幅を設定

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [ ] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
