### PR TITLE
headingの調整 #107

### DIFF
--- a/src/scss/components/_heading.scss
+++ b/src/scss/components/_heading.scss
@@ -25,11 +25,11 @@
     font-size: 12px;
     line-height: 18px;
     font-weight: 400;
-    margin-bottom: 8px;
+    margin-bottom: 12px;
     @include pc {
       font-size: 16px;
       line-height: 24px;
-      margin-bottom: 16px;
+      margin-bottom: 20px;
     }
   }
   &::before {


### PR DESCRIPTION
## Issue

#107 

## 概要

ボーダーを疑似要素にしたことでmarginがheadingの下端までの距離に変わっていたので、ボーダーの高さの分を含めて指定し直しました。

## PRを出す前に以下のチェックを行いました。

- [x] コード整形(format）を行いました
- [ ] ESLint, PugLint でエラーは出ていないことを確認しました
- [x] スマホ、PCで表示崩れがないことを確認しました
